### PR TITLE
Restoring the command line argument metricroot.

### DIFF
--- a/solidfire_graphite_collector.py
+++ b/solidfire_graphite_collector.py
@@ -211,6 +211,8 @@ parser.add_argument('-g', '--graphite', default='localhost',
     help='hostname of Graphite server to send to. default localhost')
 parser.add_argument('-t', '--port', type=int, default=2003,
     help='port to send message to. default 2003')
+parser.add_argument('-m', '--metricroot', default='netapp.solidfire.cluster',
+    help='graphite metric root. default netapp.solidfire.cluster')
 args = parser.parse_args()
 
 # Run this script as a daemon


### PR DESCRIPTION
For some reason it's not present in the github version, hence the code cannot run as it expects to initialize graphite connection with "prefix=args.metricroot"